### PR TITLE
Update modules and fix flathub build

### DIFF
--- a/com.github.nihui.waifu2x-ncnn-vulkan.metainfo.xml
+++ b/com.github.nihui.waifu2x-ncnn-vulkan.metainfo.xml
@@ -19,6 +19,7 @@
   <content_rating type="oars-1.0"/>
   <update_contact/>
   <releases>
+    <release version="20220728" date="2022-07-28"/>
     <release version="20220419" date="2022-04-19"/>
     <release version="20210521" date="2021-05-21"/>
     <release version="20210210" date="2021-02-10"/>

--- a/com.github.nihui.waifu2x-ncnn-vulkan.yaml
+++ b/com.github.nihui.waifu2x-ncnn-vulkan.yaml
@@ -27,8 +27,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/protocolbuffers/protobuf.git
-        tag: v21.4
-        commit: c9869dc7803eb0a21d7e589c40ff4f9288cd34ae
+        tag: v21.12
+        commit: f0dc78d7e6e331b8c6bb2d5283e06aa26883ca7c
         x-checker-data:
           type: git
           tag-pattern: ^v([\d.]+)$

--- a/com.github.nihui.waifu2x-ncnn-vulkan.yaml
+++ b/com.github.nihui.waifu2x-ncnn-vulkan.yaml
@@ -43,8 +43,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/nihui/waifu2x-ncnn-vulkan.git
-        tag: '20220419'
-        commit: 53e46c392ece311b3d704132f03d1a3e10276a9b
+        tag: '20220728'
+        commit: 93ed2bc36e6fb7d0c42d1034f3617bc62d35f9cd
         x-checker-data:
           is-main-source: true
           type: json

--- a/com.github.nihui.waifu2x-ncnn-vulkan.yaml
+++ b/com.github.nihui.waifu2x-ncnn-vulkan.yaml
@@ -1,7 +1,7 @@
 app-id: com.github.nihui.waifu2x-ncnn-vulkan
 
 runtime: org.freedesktop.Platform
-runtime-version: '20.08'
+runtime-version: '22.08'
 sdk: org.freedesktop.Sdk
 
 command: waifu2x-ncnn-vulkan

--- a/flathub.json
+++ b/flathub.json
@@ -1,5 +1,4 @@
 {
   "automerge-flathubbot-prs": true,
-  "skip-icons-check": true,
-  "skip-appstream-check": true
+  "skip-icons-check": true
 }


### PR DESCRIPTION
I updated the freedesktop runtime to 22.08 as 20.08 is end-of-life.

```
Info: runtime org.freedesktop.Platform branch 20.08 is end-of-life, with reason:
   org.freedesktop.Platform 20.08 is no longer receiving fixes and security updates. Please update to a supported runtime version.
Info: applications using this runtime:
   com.github.nihui.waifu2x-ncnn-vulkan
```

I also updated waifu2x-ncnn-vulkan itself and protobuf to the latest respective version.

`skip-appstream-check` makes flatpak-builder-lint throw an error, so I removed it. I think that it shouldn't be needed as there is a valid appstream file and screenshots aren't expected for cli apps anymore (https://github.com/flathub/org.flatpak.Builder/pull/111).